### PR TITLE
Add keepImportAssertions swc option

### DIFF
--- a/.swcrc
+++ b/.swcrc
@@ -9,6 +9,9 @@
         "legacyDecorator": true,
         "decoratorMetadata": true
       },
-      "target": "es2016"
+      "target": "es2016",
+      "experimental": {
+        "keepImportAssertions": true
+      }
     }
 }


### PR DESCRIPTION
So that people can import json files with import statements. Since node 16, you have to add import assertions for non-source files (like json).

Example:

```ts
import config from './config.json' assert {type: 'json'};
```

This will now copy the `assert {type: 'json'};` to the generated javascript file.