### PR TITLE
fix(builder): ignored resources that do not exist.

### DIFF
--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -16,8 +16,11 @@ export async function sleep(ms) {
 }
 
 function shouldCompileResource(name) {
-    const filePath = `./src/${name}/.nocompile`;
-    return !fs.existsSync(filePath);
+    const path = `./src/${name}`;
+    if (!fs.existsSync(path)) {
+        return false;
+    }
+    return !fs.existsSync(`${path}/.nocompile`);
 }
 
 let serverConfigPath = './server.toml';


### PR DESCRIPTION
* Prevent builder from building resources in server config, When there's no source available.